### PR TITLE
fix: fix bool eval reason, fix cover task, more test coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ integration-test: # dependent on `docker run -p 8080:8080 ghcr.io/flipt-io/flipt
 .PHONY: cover
 cover:
 	@echo "Testing with coverage..."
-	@go test -coverprofile=coverage.out -covermode=atomic ./...
+	@go test --short -coverprofile=coverage.out -covermode=atomic ./...
 	@go tool cover -html=coverage.out
 
 .PHONY: doc

--- a/pkg/provider/flipt/provider.go
+++ b/pkg/provider/flipt/provider.go
@@ -229,7 +229,7 @@ func (p Provider) BooleanEvaluation(ctx context.Context, flag string, defaultVal
 		return of.BoolResolutionDetail{
 			Value: bv,
 			ProviderResolutionDetail: of.ProviderResolutionDetail{
-				Reason: of.DefaultReason,
+				Reason: of.TargetingMatchReason,
 			},
 		}
 	}


### PR DESCRIPTION
Fixes `cover` task to not run ITs
Fixes reason on bool eval to be `TARGETING_MATCH` when appropriate
Gets us close to 100% coverage in `provider` pkg