### PR TITLE
chore: add package level godoc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ cover:
 .PHONY: doc
 doc:
 	@echo "Generating documentation..."
-	@echo "	http://localhost:6060/pkg/github.com/flipt-io/openfeature-provider-go/"
-	@godoc -http=:6060 -goroot .
+	@echo "	http://localhost:6060/pkg/go.flipt.io/flipt-io/flipt-openfeature-provider/"
+	@godoc -index -http=:6060 -goroot .
 
 .DEFAULT_GOAL := build

--- a/pkg/provider/flipt/doc.go
+++ b/pkg/provider/flipt/doc.go
@@ -1,0 +1,13 @@
+// This package provides a [Flipt] [OpenFeature Provider] for interacting with the Flipt service backend using the [OpenFeature Go SDK].
+//
+// From the [OpenFeature Specification]:
+// Providers are the "translator" between the flag evaluation calls made in application code, and the flag management system that stores flags and in some cases evaluates flags.
+//
+// You can configure the provider to connect to Flipt using any of the provided "[Option]"s.
+// This configuration allows you to specify the "[ServiceType]" (protocol), and to configure the host, port and other properties to connect to the Flipt service.
+//
+// [Flipt]: https://github.com/flipt-io/flipt
+// [OpenFeature Provider]: https://docs.openfeature.dev/docs/specification/sections/providers
+// [OpenFeature Go SDK]: https://github.com/open-feature/go-sdk
+// [OpenFeature Specification]: https://docs.openfeature.dev/docs/specification/sections/providers
+package flipt

--- a/pkg/service/flipt/doc.go
+++ b/pkg/service/flipt/doc.go
@@ -1,0 +1,3 @@
+// This package contains the lower level Flipt service client implementation.
+// Under normal circumstances, you should not need to use this package directly. Instead, you should use the `Provider` to configure and interact with the Flipt service.
+package flipt


### PR DESCRIPTION
- Adds package level godoc for `provider` and `service`
- Fixes godoc generation/server when running `make doc` locally