### PR TITLE
fix: discard unknown fields when unmarshaling json

### DIFF
--- a/pkg/service/flipt/http/service.go
+++ b/pkg/service/flipt/http/service.go
@@ -184,7 +184,7 @@ func (s *Service) GetFlag(ctx context.Context, flagKey string) (*flipt.Flag, err
 
 	if resp.StatusCode == http.StatusOK {
 		f := &flipt.Flag{}
-		if err := protojson.Unmarshal(b, f); err != nil {
+		if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(b, f); err != nil {
 			return nil, fmt.Errorf("unmarshalling response body %w", err)
 		}
 
@@ -265,7 +265,7 @@ func (s *Service) Evaluate(ctx context.Context, flagKey string, evalCtx map[stri
 
 	if resp.StatusCode == http.StatusOK {
 		e := &flipt.EvaluationResponse{}
-		if err := protojson.Unmarshal(b, e); err != nil {
+		if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(b, e); err != nil {
 			return nil, fmt.Errorf("unmarshalling response body %w", err)
 		}
 

--- a/pkg/service/flipt/http/service_test.go
+++ b/pkg/service/flipt/http/service_test.go
@@ -66,6 +66,17 @@ func TestGetFlag(t *testing.T) {
 			},
 		},
 		{
+			name:         "unknown field",
+			responseBody: []byte(`{"key":"foo","name":"Flag Name","description":"Flag Description","enabled":true, "what": "is this"}`),
+			responseCode: http.StatusOK,
+			expected: &flipt.Flag{
+				Key:         "foo",
+				Name:        "Flag Name",
+				Description: "Flag Description",
+				Enabled:     true,
+			},
+		},
+		{
 			name:         "flag not found",
 			responseBody: []byte(`{"error":"flag not found","code":5}`),
 			responseCode: http.StatusNotFound,
@@ -134,6 +145,15 @@ func TestEvaluate(t *testing.T) {
 		{
 			name:         "success",
 			responseBody: []byte(`{"flag_key":"foo","match":true}`),
+			responseCode: http.StatusOK,
+			expected: &flipt.EvaluationResponse{
+				FlagKey: "foo",
+				Match:   true,
+			},
+		},
+		{
+			name:         "unknown field",
+			responseBody: []byte(`{"flag_key":"foo","match":true, "what": "is this"}`),
 			responseCode: http.StatusOK,
 			expected: &flipt.EvaluationResponse{
 				FlagKey: "foo",


### PR DESCRIPTION
Fixes an issue where json unmarshalling for the HTTP service was returning an error if unknown fields (new fields) were in the response.

## Before (with new tests)

```
            	Error:      	Received unexpected error:
            	            	unmarshalling response body proto: (line 1:82): unknown field "what"
            	Test:       	TestGetFlag/unknown_field



            	Error:      	Received unexpected error:
            	            	unmarshalling response body proto: (line 1:33): unknown field "what"
            	Test:       	TestEvaluate/unknown_field
```

## After 

Tests pass